### PR TITLE
fix: make service account leave group once created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 # telegram api
 *.session
 *.session-journal
+
+# Run Tunnel
+run-tunnel.sh

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python Debugger: Module",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "app.main:app",
+                "--reload",
+                "--host", "0.0.0.0",
+                "--port", "8000"
+            ],
+        }
+    ]
+}

--- a/app/services/core/auth.py
+++ b/app/services/core/auth.py
@@ -33,8 +33,8 @@ class BearerAuthWithRefresh(httpx.Auth):
     async def _async_get_new_token(self):
         """Calls the /token endpoint to generate a new token."""
         # Note: We use a separate client to avoid recursion issues
-        with httpx.Client() as client:
-            response = client.post(self.token_url, data=self.client_credentials.model_dump_json())
+        async with httpx.AsyncClient() as client:
+            response = await client.post(self.token_url, data=self.client_credentials.model_dump_json())
             if response.status_code != HTTPStatus.OK:
                 # Forward the error gotten from /token if refresh fails
                 response.raise_for_status()

--- a/app/telegram/handlers/start.py
+++ b/app/telegram/handlers/start.py
@@ -26,8 +26,8 @@ Select a counselor to see their profile from the list below. When you're ready, 
 
 
 async def start(update: Update, _context: ContextTypes.DEFAULT_TYPE):
-    chat_id = update.effective_chat.id
-    alias = await create_or_get_alias(chat_id)
+    user_id = update.effective_user.id
+    alias = await create_or_get_alias(user_id)
     counselors = await get_counselors()
 
     keyboard = [[InlineKeyboardButton(c.name, callback_data=f"select:{c.id}")] for c in counselors]

--- a/app/util/helpers.py
+++ b/app/util/helpers.py
@@ -1,0 +1,3 @@
+def sanitize_supergroup_id_to_negative(group_id: int) -> int:
+    return int(f"-100{group_id}")
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def mock_update():
     """Create a mock Telegram Update object."""
     update = MagicMock()
     update.effective_chat.id = 12345
+    update.effective_user.id = 11111
     update.message = MagicMock()
     update.message.chat.id = 12345
     update.message.text = "Test message"
@@ -77,6 +78,7 @@ def mock_update():
     update.callback_query.message.edit_text = AsyncMock()
     update.callback_query.answer = AsyncMock()
     update.callback_query.data = "test:data"
+    update.callback_query.from_user.id = 22222
     return update
 
 

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -157,7 +157,9 @@ async def test_get_group_link_success():
             telegram_user_id=hashed_user, counselor_id=c_id
         ).model_dump_json()
 
-        mock_post.assert_called_once_with(f"{settings.core_api_base}/groups/link", data=expected_payload)
+        mock_post.assert_called_once_with(
+            f"{settings.core_api_base}/groups/link", data=expected_payload
+        )
         assert result == mock_link
 
 
@@ -189,7 +191,9 @@ async def test_get_group_link_without_link():
             telegram_user_id=hashed_id, counselor_id=c_id
         ).model_dump_json()
 
-        mock_post.assert_called_once_with(f"{settings.core_api_base}/groups/link", data=expected_payload)
+        mock_post.assert_called_once_with(
+            f"{settings.core_api_base}/groups/link", data=expected_payload
+        )
         assert result is None
 
 

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 from app.services.core.auth import BearerAuthWithRefresh
@@ -109,9 +108,7 @@ class TestAuthFlow:
         mock_response_200 = MagicMock()
         mock_response_200.status_code = 200
 
-        with patch.object(
-            auth_instance, "sync_get_token", side_effect=["token1", "token2"]
-        ):
+        with patch.object(auth_instance, "sync_get_token", side_effect=["token1", "token2"]):
             gen = auth_instance.auth_flow(mock_request)
 
             # First request
@@ -129,9 +126,7 @@ class TestAuthFlow:
         mock_response_403 = MagicMock()
         mock_response_403.status_code = 403
 
-        with patch.object(
-            auth_instance, "sync_get_token", side_effect=["token1", "token2"]
-        ):
+        with patch.object(auth_instance, "sync_get_token", side_effect=["token1", "token2"]):
             gen = auth_instance.auth_flow(mock_request)
             next(gen)
 
@@ -146,9 +141,7 @@ class TestAuthFlow:
         mock_response_401 = MagicMock()
         mock_response_401.status_code = 401
 
-        with patch.object(
-            auth_instance, "sync_get_token", side_effect=["t1", "t2", "t3", "t4"]
-        ):
+        with patch.object(auth_instance, "sync_get_token", side_effect=["t1", "t2", "t3", "t4"]):
             gen = auth_instance.auth_flow(mock_request)
             next(gen)  # Initial request
 
@@ -175,51 +168,6 @@ class TestAuthFlow:
             # Send success response, generator should complete
             with pytest.raises(StopIteration):
                 gen.send(mock_response_200)
-
-
-class TestAsyncGetNewToken:
-    """Tests for _async_get_new_token method."""
-
-    @pytest.mark.asyncio
-    async def test_async_get_new_token_success(self, auth_instance):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"access_token": "async_token_456"}
-
-        with patch("app.services.core.auth.httpx.Client") as mock_client_class:
-            mock_client = MagicMock()
-            mock_client.__enter__.return_value = mock_client
-            mock_client.__exit__.return_value = None
-            mock_client.post.return_value = mock_response
-            mock_client_class.return_value = mock_client
-
-            result = await auth_instance._async_get_new_token()
-
-            assert result == "async_token_456"
-            mock_client.post.assert_called_once_with(
-                auth_instance.token_url,
-                data=auth_instance.client_credentials.model_dump_json(),
-            )
-
-    @pytest.mark.asyncio
-    async def test_async_get_new_token_raises_on_error(self, auth_instance):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 500
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            message="Internal Server Error",
-            request=MagicMock(spec=httpx.Request),
-            response=mock_response,
-        )
-
-        with patch("app.services.core.auth.httpx.Client") as mock_client_class:
-            mock_client = MagicMock()
-            mock_client.__enter__.return_value = mock_client
-            mock_client.__exit__.return_value = None
-            mock_client.post.return_value = mock_response
-            mock_client_class.return_value = mock_client
-
-            with pytest.raises(httpx.HTTPStatusError):
-                await auth_instance._async_get_new_token()
 
 
 class TestAsyncAuthFlow:
@@ -262,9 +210,7 @@ class TestAsyncAuthFlow:
         mock_response_401 = MagicMock()
         mock_response_401.status_code = 401
 
-        with patch.object(
-            auth_instance, "_async_get_new_token", side_effect=["token1", "token2"]
-        ):
+        with patch.object(auth_instance, "_async_get_new_token", side_effect=["token1", "token2"]):
             gen = auth_instance.async_sync_auth_flow(mock_request)
 
             await gen.asend(None)
@@ -281,9 +227,7 @@ class TestAsyncAuthFlow:
         mock_response_404 = MagicMock()
         mock_response_404.status_code = 404
 
-        with patch.object(
-            auth_instance, "_async_get_new_token", side_effect=["token1", "token2"]
-        ):
+        with patch.object(auth_instance, "_async_get_new_token", side_effect=["token1", "token2"]):
             gen = auth_instance.async_sync_auth_flow(mock_request)
             await gen.asend(None)
 

--- a/tests/test_handlers_callbacks.py
+++ b/tests/test_handlers_callbacks.py
@@ -35,7 +35,7 @@ async def test_callbacks_select_with_group_link(mock_update):
         # Verify API calls
         mock_get_counselor.assert_called_once_with(mock_counselor.id)
         mock_get_group_link.assert_called_once_with(
-            mock_update.callback_query.message.chat.id, mock_counselor.id
+            mock_update.callback_query.from_user.id, mock_counselor.id
         )
 
         # Verify message was edited
@@ -111,7 +111,7 @@ async def test_callbacks_start_session(mock_update):
 
         await callbacks(mock_update, MagicMock())
 
-        mock_create_or_get_alias.assert_called_once_with(mock_update.effective_chat.id)
+        mock_create_or_get_alias.assert_called_once_with(mock_update.callback_query.from_user.id)
 
         mock_create_group.assert_called_once_with(
             mock_alias,
@@ -141,8 +141,8 @@ async def test_callbacks_home(mock_update):
 
     mock_alias = "test_alias_123"
     mock_counselors = [
-        CounselorInfo(id="1", name="John Doe"),
-        CounselorInfo(id="2", name="Jane Smith"),
+        CounselorInfo(id=1, name="John Doe"),
+        CounselorInfo(id=2, name="Jane Smith"),
     ]
 
     with (
@@ -159,7 +159,7 @@ async def test_callbacks_home(mock_update):
         await callbacks(mock_update, MagicMock())
 
         # Verify API calls
-        mock_alias_func.assert_called_once_with(mock_update.callback_query.message.chat.id)
+        mock_alias_func.assert_called_once_with(mock_update.callback_query.from_user.id)
         mock_counselors_func.assert_called_once()
 
         # Verify message was edited

--- a/tests/test_handlers_start.py
+++ b/tests/test_handlers_start.py
@@ -15,8 +15,8 @@ async def test_start_handler_success(mock_update):
 
     mock_alias = "test_alias_123"
     mock_counselors = [
-        CounselorInfo(id="1", name="John Doe"),
-        CounselorInfo(id="2", name="Jane Smith"),
+        CounselorInfo(id=1, name="John Doe"),
+        CounselorInfo(id=2, name="Jane Smith"),
     ]
 
     with (
@@ -33,7 +33,7 @@ async def test_start_handler_success(mock_update):
         await start(mock_update, MagicMock())
 
         # Verify API calls
-        mock_alias_func.assert_called_once_with(mock_update.effective_chat.id)
+        mock_alias_func.assert_called_once_with(mock_update.effective_user.id)
         mock_counselors_func.assert_called_once()
 
         # Verify message was sent


### PR DESCRIPTION
- Make the service account Leave groups once it creates them
- Correctly check if the bot is an admin. It was using the `chat_member` from the conversation with the bot.
- Correctly use async for some auth functions. Might need to force async usage in the future.

closes #10 